### PR TITLE
Update pg-promise to v3.1.x and utilize SQL names.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,7 @@
     "koa-logger": "^2.0.0",
     "koa-router": "^7.0.1",
     "node-pg-migrate": "0.0.9",
-    "pg-promise": "^2.8.5"
+    "pg-promise": "^3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",

--- a/api/src/models/base.js
+++ b/api/src/models/base.js
@@ -14,7 +14,7 @@ const prototype = {
   },
   read(id) {
     const query = `
-      SELECT * FROM ${this.tableName} WHERE id = $1^
+      SELECT * FROM ${this.tableName} WHERE id = $1~
     `;
     const response = this.db.one(query, id)
       .finally(this.close());
@@ -30,7 +30,7 @@ const prototype = {
   },
   update(fieldObject) {
     const query = `
-      UPDATE ${this.tableName} SET $/key^/ = $/value/ WHERE id = $/id/
+      UPDATE ${this.tableName} SET $/key~/ = $/value/ WHERE id = $/id/
     `;
     const response = this.db.none(query, fieldObject)
       .finally(this.close());
@@ -38,7 +38,7 @@ const prototype = {
   },
   destroy(id) {
     const query = `
-      DELETE FROM ${this.tableName} WHERE id = $1^
+      DELETE FROM ${this.tableName} WHERE id = $1
     `;
     const response = this.db.none(query, id)
       .finally(this.close());

--- a/api/src/models/crane.js
+++ b/api/src/models/crane.js
@@ -69,7 +69,7 @@ craneModel.findWithin = function(querystring) {
       ST_AsGeoJSON(r.location)::json as geometry,
       row_to_json((SELECT l FROM (SELECT id, user_id) AS l)) AS properties
       FROM ${this.tableName} AS r WHERE ST_DWithin(
-        r.location, 'POINT($/lng^/ $/lat^/)', $/radius^/
+        r.location, 'POINT($/lng~/ $/lat~/)', $/radius~/
       )
     ) AS f
   `;

--- a/api/src/models/report.js
+++ b/api/src/models/report.js
@@ -62,7 +62,7 @@ reportModel.findWithin = function(querystring) {
       ST_AsGeoJSON(r.location)::json as geometry,
       row_to_json((SELECT l FROM (SELECT id, user_id) AS l)) AS properties
       FROM ${this.tableName} AS r WHERE ST_DWithin(
-        r.location, 'POINT($/lng^/ $/lat^/)', $/radius^/
+        r.location, 'POINT($/lng~/ $/lat~/)', $/radius~/
       )
     ) AS f
   `;


### PR DESCRIPTION
Resolves issue #2  and guards against SQL injections
possible with raw text variables within queries.