### PR TITLE
Revisit use of pg-promise SQL names.

### DIFF
--- a/api/src/models/base.js
+++ b/api/src/models/base.js
@@ -14,7 +14,7 @@ const prototype = {
   },
   read(id) {
     const query = `
-      SELECT * FROM ${this.tableName} WHERE id = $1~
+      SELECT * FROM ${this.tableName} WHERE id = $1
     `;
     const response = this.db.one(query, id)
       .finally(this.close());

--- a/api/src/models/crane.js
+++ b/api/src/models/crane.js
@@ -69,7 +69,7 @@ craneModel.findWithin = function(querystring) {
       ST_AsGeoJSON(r.location)::json as geometry,
       row_to_json((SELECT l FROM (SELECT id, user_id) AS l)) AS properties
       FROM ${this.tableName} AS r WHERE ST_DWithin(
-        r.location, 'POINT($/lng~/ $/lat~/)', $/radius~/
+        r.location, 'POINT($/lng/ $/lat/)', $/radius/
       )
     ) AS f
   `;

--- a/api/src/models/report.js
+++ b/api/src/models/report.js
@@ -62,7 +62,7 @@ reportModel.findWithin = function(querystring) {
       ST_AsGeoJSON(r.location)::json as geometry,
       row_to_json((SELECT l FROM (SELECT id, user_id) AS l)) AS properties
       FROM ${this.tableName} AS r WHERE ST_DWithin(
-        r.location, 'POINT($/lng~/ $/lat~/)', $/radius~/
+        r.location, 'POINT($/lng/ $/lat/)', $/radius/
       )
     ) AS f
   `;


### PR DESCRIPTION
Resolves issue #2. Fix overuse of escaping on variables
that are __not__ SQL names/identifiers, e.g. table & column names.